### PR TITLE
Adds link to comparison of application starters

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This is the generator of the next generation fullstack applications.
 
 Forget about initial setup, ```yo ng-fullstack``` and be happy!
 
+This project is one of many things that you can use to get started building a new app.  
+For a detailed comparison of the options and trade-offs between them, please visit [this](http://www.dancancro.com/comparison-of-angularjs-application-starters) link.
 
 # what am I going to be using?
 


### PR DESCRIPTION
This commit puts a link on the project readme to a giant spreadsheet comparing project starter options.  This will help users to make informed decisions at this important stage of the project and get the tool that best fits their needs.

I have added a column to the spreadsheet for generator-ng-fullstack.  If you have any facts about it to add, your help is most welcome.