### PR TITLE
Fixed Gulpfile issue (#47)

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -3,6 +3,7 @@
 // TODO: modularize (https://github.com/ericmdantas/generator-ng-fullstack/issues/6)
 
 var gulp = require('gulp');
+var babel = require('gulp-babel');
 var uglify = require('gulp-uglify');
 var cssmin = require('gulp-minify-css');
 var usemin = require('gulp-usemin');
@@ -136,11 +137,12 @@ gulp.task('watch', ['del_temp', 'bower', 'build_temp', 'browser_sync'], function
   _watchable.push(_less);
   _watchable.push(_images);
   _watchable.push(_partials);
+  _watchable.push(_views);
   _watchable.push(_fonts);
   _watchable.push(_bower);
   _watchable.push(_es6);
 
-  return gulp.watch(_watchable, ['compile:babel', 'bower', 'build_temp', 'browser_sync']);
+  return gulp.watch(_watchable, ['del_temp', 'bower', 'build_temp', 'browser_sync']);
 });
 
 gulp.task('del_temp', function()

--- a/app/templates/_gulpfile_ng2.js
+++ b/app/templates/_gulpfile_ng2.js
@@ -3,6 +3,7 @@
 // TODO: modularize (https://github.com/ericmdantas/generator-ng-fullstack/issues/6)
 
 var gulp = require('gulp');
+var babel = require('gulp-babel');
 var uglify = require('gulp-uglify');
 var cssmin = require('gulp-minify-css');
 var usemin = require('gulp-usemin');
@@ -126,11 +127,12 @@ gulp.task('watch', ['del_temp', 'build_temp', 'browser_sync'], function()
   _watchable.push(_less);
   _watchable.push(_images);
   _watchable.push(_partials);
+  _watchable.push(_views);
   _watchable.push(_fonts);
   _watchable.push(_bower);
   _watchable.push(_es6);
 
-  return gulp.watch(_watchable, ['compile:babel', 'bower', 'build_temp', 'browser_sync']);
+  return gulp.watch(_watchable, ['del_temp', 'bower', 'build_temp', 'browser_sync']);
 });
 
 gulp.task('del_temp', function()


### PR DESCRIPTION
Fixed issue #47 .

Modified Gulpfile (both for ng and ng2) to include declaration for babel, watch for changes in views and delete temporary files before rebuilding (compile:babel task is redundant there and throws ENOENT, since old __tmp was not deleted).