### PR TITLE
Fix some issues in the endpoint generator for Node using no transpiler

### DIFF
--- a/endpoint/templates/node/no_transpiler/endpoint.controller.js
+++ b/endpoint/templates/node/no_transpiler/endpoint.controller.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import <%= name %>DAO from '../dao/<%= name %>-dao';
+const <%= name %> = require('../dao/<%= name %>-dao');
 
 module.exports = class <%= name %>Controller {
   static getAll(req, res) {

--- a/endpoint/templates/node/no_transpiler/endpoint.controller.js
+++ b/endpoint/templates/node/no_transpiler/endpoint.controller.js
@@ -19,7 +19,7 @@ module.exports = class <%= name %>Controller {
       .catch(error => res.status(400).json(error));
   }
 
-  static remove(req, res) {
+  static removeById(req, res) {
     let _id = req.params.id;
 
     <%= name %>DAO

--- a/endpoint/templates/node/no_transpiler/endpoint.dao.js
+++ b/endpoint/templates/node/no_transpiler/endpoint.dao.js
@@ -33,7 +33,7 @@ const _ = require('lodash');
   });
 }
 
-<%= nameLowerCase %>chema.statics.removeById = (id) => {
+<%= nameLowerCase %>Schema.statics.removeById = (id) => {
   return new Promise((resolve, reject) => {
     if (!_.isString(id)) {
       return reject(new TypeError('Id is not a valid string.'));


### PR DESCRIPTION
There were some issues with the naming of some variables, methods, and invalid import statements.
This resolves the ones I've found - now using ng-fullstack:endpoint should generate valid code.