### PR TITLE
added * to fix ts watch

### DIFF
--- a/app/templates/tasks/client/ng2/watch.js
+++ b/app/templates/tasks/client/ng2/watch.js
@@ -16,7 +16,7 @@ gulp.task(tasks.CLIENT_WATCH, [tasks.CLIENT_BUILD_TS, <% if (!!stylePreprocessor
 
   let _watchable = [];
 
-  _watchable.push(base.DEV + "**/.ts");
+  _watchable.push(base.DEV + "**/*.ts");
   _watchable.push(base.DEV + "**/*.css");
   _watchable.push(base.DEV + "**/*.html");
   <% if (stylePreprocessor === "less") { %>


### PR DESCRIPTION
This is literally just adding a `*` to the watch.js file for ng2 to watch .ts files. 
It fixes this issue: https://github.com/ericmdantas/generator-ng-fullstack/issues/258