### PR TITLE
Updated for the correct function

### DIFF
--- a/app/templates/client/vue2/dev/todo/components/todo-cmp.js
+++ b/app/templates/client/vue2/dev/todo/components/todo-cmp.js
@@ -37,7 +37,7 @@
         </div>
       </div>
     `,
-    ready() {
+    mounted() {
       this.getAll();
     },
     methods: {


### PR DESCRIPTION
Vue 2 no longer uses `ready: function(){}`, it's been relpaced with `mounted: function(){}`. The change reflect this.

Came to this conclusion from #277.